### PR TITLE
Passing clientSecret when initializing OAuth2 to be more compatible with RFC

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -22,7 +22,7 @@ function PasswordGrantStrategy(options, verify) {
   this.name = 'password-grant';
   this._verify = verify;
 
-  this._oauth2 = new OAuth2(options.clientID, '', '', '', options.tokenURL, options.customHeaders);
+  this._oauth2 = new OAuth2(options.clientID, options.clientSecret, '', '', options.tokenURL, options.customHeaders);
 
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;


### PR DESCRIPTION
Oauth2 RFC Section 2.3 (if the authorization server requires authentication, pass clientId and clientSecret in basic auth or in body)
