### PR TITLE
Allow for authorizationParams inside authenticate() method

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -39,7 +39,7 @@ PasswordGrantStrategy.prototype.authenticate = function(req, options) {
   if (!options.username) { throw new TypeError('PasswordGrantStrategy requires a username param'); }
   if (!options.password) { throw new TypeError('PasswordGrantStrategy requires a password param'); }
 
-  var params = {};
+  var params = self.authorizationParams(options);
   params.grant_type = 'password';
   params.username = options.username;
   params.password = options.password;


### PR DESCRIPTION
As noted in the issue I need to pass scope as parameter to getOAuthAccessToken method. However, currently this is not possible.
Will be happy for any feedback or comments on that PR.