### PR TITLE
Fail instead of error on invalid credentials

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -46,7 +46,14 @@ PasswordGrantStrategy.prototype.authenticate = function(req, options) {
 
   this._oauth2.getOAuthAccessToken(null, params,
     function(err, accessToken, refreshToken, params) {
-      if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
+      if (err) {
+        var oauthError = self._createOAuthError('Failed to obtain access token', err)
+        if (oauthError.name == 'AuthorizationError' && oauthError.code == 'invalid_grant') {
+          return self.fail(oauthError)
+        } else {
+          return self.error(oauthError)
+        }
+      }
 
       self._loadUserProfile(accessToken, function(err, profile) {
         if (err) { return self.error(err); }


### PR DESCRIPTION
Currently when entering invalid credentials there's going to be an error that is not easy to recover from.
I made some changes so invalid credentials are only treated as a failure and the execution actually continues from passport into the failure settings.
See issue #4 for the problem.