### PR TITLE
Add Scope to params from options

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -24,6 +24,8 @@ function PasswordGrantStrategy(options, verify) {
 
   this._oauth2 = new OAuth2(options.clientID, options.clientSecret, '', '', options.tokenURL, options.customHeaders);
 
+  this._scope = options.scope;
+  this._scopeSeparator = options.scopeSeparator || ' ';
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
 }
@@ -43,6 +45,13 @@ PasswordGrantStrategy.prototype.authenticate = function(req, options) {
   params.grant_type = 'password';
   params.username = options.username;
   params.password = options.password;
+  var scope = options.scope || this._scope
+  if (scope) {
+    if (Array.isArray(scope)) {
+      scope = scope.join(this._scopeSeparator)
+    }
+    params.scope = scope
+  }
 
   this._oauth2.getOAuthAccessToken(null, params,
     function(err, accessToken, refreshToken, params) {


### PR DESCRIPTION
Due to this issue: https://github.com/leftmostcat/passport-oauth2-password-grant/issues/6
Some people would like to send scope to auth when using password grant flow. 
Scope is also part of OAuth2 options